### PR TITLE
Basic SMS messages structure

### DIFF
--- a/networklibrary/src/main/java/com/eis/smsnetwork/RequestType.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/RequestType.java
@@ -1,0 +1,63 @@
+package com.eis.smsnetwork;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This enum contains the Request Types, which are the CODE placed at the beginning of every message
+ * sent through the network. They identify the command contained in each message. Depending upon
+ * the RequestType received, different actions are performed.
+ * It is identifies by the listener receiver.
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ */
+public enum RequestType {
+
+    // Requests to manage subscribers
+    Invite("IN"),
+    AcceptInvitation("AI"),
+    AddPeer("AP"),
+    RemovePeer("RP"),
+
+    // Requests to manage the dictionary
+    AddResource("AR"),
+    RemoveResource("RR");
+
+    private final String command;
+
+    RequestType(String command) {
+        this.command = command;
+    }
+
+    public String asString() {
+        return command;
+    }
+
+    private static final Map<String, RequestType> lookup = new HashMap<>();
+
+    /*
+     * Populate the lookup table on loading time
+     * The lookup table is used to change a command string into a RequestType
+     * Trick learned online. Since that block is static it will get executed really early,
+     * even before the constructor.
+     *
+     * @author Marco Cognolato
+     */
+    static {
+        for (RequestType command : RequestType.values()) {
+            lookup.put(command.asString(), command);
+        }
+    }
+
+    /**
+     * Returns the RequestType given the string identifier
+     *
+     * @param command The String command of this
+     * @return Returns the corresponding RequestType if it exists, null otherwise
+     * @author Marco Cognolato
+     */
+    public static RequestType get(String command) {
+        return lookup.get(command);
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/SMSFailReason.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/SMSFailReason.java
@@ -1,0 +1,48 @@
+package com.eis.smsnetwork;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.FailReason;
+
+public class SMSFailReason extends FailReason {
+
+    /**
+     * Error when a resource is not available
+     */
+    public static final SMSFailReason NO_RESOURCE = new SMSFailReason("ResourceNotAvailable");
+
+    /**
+     * Error when a peer is not available
+     */
+    public static final SMSFailReason NO_PEER = new SMSFailReason("PeerNotAvailable");
+
+    /**
+     * Error when a request takes too long
+     */
+    public static final SMSFailReason REQUEST_EXPIRED = new SMSFailReason("RequestExpired");
+
+    /**
+     * Error when a message couldn't be sent
+     */
+    public static final SMSFailReason MESSAGE_SEND_ERROR  = new SMSFailReason("ErrorWhileSendingMessage");
+
+    /**
+     * Private constructor as suggested in the TypeSafe enum pattern.
+     *
+     * @param name The name of the enumeration.
+     */
+    protected SMSFailReason(final @NonNull String name) {
+        super(name);
+    }
+
+    /**
+     * toString override.
+     *
+     * @return The name of the fail reason.
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/SMSJoinableNetManager.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/SMSJoinableNetManager.java
@@ -1,0 +1,74 @@
+package com.eis.smsnetwork;
+
+import com.eis.communication.network.FailReason;
+import com.eis.communication.network.Invitation;
+import com.eis.communication.network.JoinableNetworkManager;
+import com.eis.communication.network.listeners.JoinInvitationListener;
+import com.eis.smslibrary.SMSPeer;
+
+/**
+ * Concrete JoinableNetwork for SMS Messages
+ * If a listener is NOT set (using {@link #setJoinInvitationListener(JoinInvitationListener)})
+ * the method {@link #acceptJoinInvitation(Invitation)} will be called automatically,
+ * else you should call that from the listener if you want to accept an invitation
+ *
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSJoinableNetManager extends SMSNetworkManager
+        implements JoinableNetworkManager<String, String, SMSPeer, SMSFailReason, Invitation<SMSPeer>> {
+
+    private static SMSJoinableNetManager instance;
+
+    private JoinInvitationListener<Invitation<SMSPeer>> invitationListener = null;
+
+    /**
+     * Private constructor of the singleton.
+     */
+    private SMSJoinableNetManager() {
+    }
+
+    /**
+     * Gets the only instance of this class.
+     *
+     * @return the only instance of SMSNetworkManager.
+     */
+    public static SMSJoinableNetManager getInstance() {
+        if(instance == null) instance = new SMSJoinableNetManager();
+        return instance;
+    }
+
+    /**
+     * Accepts a given join invitation.
+     * If a listener is NOT set (using {@link #setJoinInvitationListener(JoinInvitationListener)})
+     * this method will be called automatically, else you should call this from the listener
+     * if you want to accept an invitation
+     *
+     * @param invitation The invitation previously received.
+     */
+    @Override
+    public void acceptJoinInvitation(Invitation invitation) {
+        //redirects the call to the acceptJoinInvitation in the parent class.
+        super.acceptJoinInvitation(invitation);
+    }
+
+    /**
+     * Sets a listener waiting for network invitations
+     *
+     * @param joinInvitationListener Listener called upon invitation received.
+     */
+    @Override
+    public void setJoinInvitationListener(JoinInvitationListener<Invitation<SMSPeer>> joinInvitationListener) {
+        invitationListener = joinInvitationListener;
+    }
+
+    /**
+     * When an invitation in received separates between auto accepting and forwarding it to the
+     * user depending if a listener was set by the user
+     * @param invitation The invitation received
+     */
+    public void checkInvitation(Invitation<SMSPeer> invitation){
+        if(invitationListener == null) acceptJoinInvitation(invitation);
+        invitationListener.onJoinInvitationReceived(invitation);
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/SMSNetworkManager.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/SMSNetworkManager.java
@@ -1,0 +1,130 @@
+package com.eis.smsnetwork;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.communication.network.FailReason;
+import com.eis.communication.network.Invitation;
+import com.eis.communication.network.NetDictionary;
+import com.eis.communication.network.NetSubscriberList;
+import com.eis.communication.network.NetworkManager;
+import com.eis.communication.network.listeners.GetResourceListener;
+import com.eis.communication.network.listeners.InviteListener;
+import com.eis.communication.network.listeners.RemoveResourceListener;
+import com.eis.communication.network.listeners.SetResourceListener;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.smsnetcommands.SMSAcceptInvite;
+import com.eis.smsnetwork.smsnetcommands.SMSAddResource;
+import com.eis.smsnetwork.smsnetcommands.SMSInvitePeer;
+import com.eis.smsnetwork.smsnetcommands.SMSRemoveResource;
+
+/**
+ * The manager class of the network.
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ */
+public class SMSNetworkManager implements NetworkManager<String, String, SMSPeer, SMSFailReason> {
+
+    private NetSubscriberList<SMSPeer> netSubscribers = new SMSNetSubscriberList();
+    private NetDictionary<String, String> netDictionary = new SMSNetDictionary();
+
+    /**
+     * @return netSubscribers
+     */
+    public NetSubscriberList<SMSPeer> getNetSubscriberList() {
+        return netSubscribers;
+    }
+
+    /**
+     * @return netDictionary
+     */
+    public NetDictionary<String, String> getNetDictionary() {
+        return netDictionary;
+    }
+
+    /**
+     * Starts a setResource request to the net
+     *
+     * @param key                 The key identifier for the resource.
+     * @param value               The identified value of the resource.
+     * @param setResourceListener Listener called on resource successfully saved or on fail.
+     * @author Marco Cognolato
+     */
+    @Override
+    public void setResource(String key, String value, SetResourceListener<String, String, SMSFailReason> setResourceListener) {
+        CommandExecutor.execute(new SMSAddResource(key, value, netDictionary));
+    }
+
+    /**
+     * Starts a getResource request to the net
+     *
+     * @param key                 The key identifier for the resource.
+     * @param getResourceListener Listener called on resource successfully retrieved or on fail.
+     * @author Marco Cognolato
+     */
+    @Override
+    public void getResource(String key, GetResourceListener<String, String, SMSFailReason> getResourceListener) {
+        String resource = netDictionary.getResource(key);
+        if (resource != null) getResourceListener.onGetResource(key, resource);
+        else{
+            getResourceListener.onGetResourceFailed(key, SMSFailReason.NO_RESOURCE);
+        }
+    }
+
+    /**
+     * Starts a remove resource request to the net
+     *
+     * @param key                    The key identifier for the resource.
+     * @param removeResourceListener Listener called on resource successfully removed or on fail.
+     * @author Marco Cognolato
+     */
+    @Override
+    public void removeResource(String key, RemoveResourceListener<String, SMSFailReason> removeResourceListener) {
+        CommandExecutor.execute(new SMSRemoveResource(key, netDictionary));
+    }
+
+    /**
+     * Starts an invite operation to the net
+     *
+     * @param peer           The address of the user to invite to join the network.
+     * @param inviteListener Listener called on user invited or on fail.
+     * @author Marco Cognolato
+     */
+    @Override
+    public void invite(SMSPeer peer, InviteListener<SMSPeer, SMSFailReason> inviteListener) {
+        CommandExecutor.execute(new SMSInvitePeer(peer));
+    }
+
+    /**
+     * Accepts a given join invitation.
+     *
+     * @param invitation The invitation previously received.
+     */
+    public void acceptJoinInvitation(Invitation invitation) {
+        // N.B. this function provides an implementation for automatically joining a network.
+        // while SMSJoinableNetManager uses this function by sending the request to the user
+        // using a listener set by the user.
+        CommandExecutor.execute(new SMSAcceptInvite((SMSPeer)invitation.getInviterPeer(), netSubscribers));
+    }
+
+    /**
+     * Sets a given list of subscribers, to provide the network
+     * with your own implementation
+     *
+     * @param list A NetSubscriberList of type <SMSPeer> to provide
+     */
+    public void setNetSubscriberList(@NonNull NetSubscriberList<SMSPeer> list) {
+
+    }
+
+    /**
+     * Sets a given dictionary of resources, to provide the network
+     * with your own implementation
+     *
+     * @param dictionary A NetDictionary of type <String,String> to provide
+     */
+    public void setNetDictionary(@NonNull NetDictionary<String, String> dictionary) {
+
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastSender.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastSender.java
@@ -1,0 +1,29 @@
+package com.eis.smsnetwork.broadcast;
+
+import com.eis.smslibrary.SMSHandler;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.SMSNetSubscriberList;
+
+import java.util.List;
+
+/**
+ * This class allows to send a command in broadcast to the entire network
+ */
+public class BroadcastSender {
+
+    /**
+     * Broadcasts a message to the specified subscribers.
+     *
+     * @param receivers The {@link com.eis.smsnetwork.SMSNetSubscriberList} to which to send the message.
+     * @param textMessage The {@link String} to broadcast.
+     */
+    public static void broadcastMessage(List<SMSPeer> receivers, String textMessage) {
+        //Naive implementation of a broadcast: this node sends a message to each subscriber
+        for (SMSPeer peer : receivers) {
+            SMSMessage message = new SMSMessage(peer, textMessage);
+            SMSHandler.getInstance().sendMessage(message);
+        }
+    }
+
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAcceptInvite.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAcceptInvite.java
@@ -1,0 +1,32 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import com.eis.communication.network.NetSubscriberList;
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.smslibrary.SMSHandler;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.RequestType;
+
+/**
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSAcceptInvite extends com.eis.communication.network.commands.AcceptInvite<SMSPeer> {
+
+    /**
+     * Constructor for SMSAcceptInvite command, requires data to work
+     *
+     * @param inviter        The SMSPeer who sent the invitation to his network
+     * @param netSubscribers The list of subscribers of this network (so they can be joined)
+     */
+    public SMSAcceptInvite(SMSPeer inviter, NetSubscriberList<SMSPeer> netSubscribers) {
+        super(inviter, netSubscribers);
+    }
+
+    protected void execute() {
+        //TODO other than sending the AcceptInvitation, you should send all the peers in my network,
+        //so he can notify we were added at the same time
+        SMSHandler.getInstance().sendMessage(new SMSMessage(inviter, RequestType.AcceptInvitation.asString()));
+        CommandExecutor.execute(new SMSAddPeer(inviter, netSubscribers));
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAddPeer.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAddPeer.java
@@ -1,0 +1,34 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetSubscriberList;
+import com.eis.smslibrary.SMSPeer;
+
+/**
+ * Command to add a peer to the Subscribers list
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSAddPeer extends com.eis.communication.network.commands.AddPeer<SMSPeer> {
+
+    /**
+     * SMSAddPeer command constructor, receives the data it needs to operate on.
+     *
+     * @param peer           The SMSPeer to add to the network
+     * @param netSubscribers The subscribers to notify of the newest member
+     */
+    public SMSAddPeer(@NonNull SMSPeer peer, @NonNull NetSubscriberList<SMSPeer> netSubscribers) {
+        super(peer, netSubscribers);
+    }
+
+    /**
+     * Adds the peer to the subscribers list and broadcasts it to the net
+     */
+    protected void execute() {
+        netSubscribers.addSubscriber(peer);
+        //TODO broadcast
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAddResource.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSAddResource.java
@@ -1,0 +1,34 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetDictionary;
+
+/**
+ * Command to add a resource to the net dictionary
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSAddResource extends com.eis.communication.network.commands.AddResource<String, String> {
+
+    /**
+     * Constructor for the SMSAddResource command, needs the data to operate
+     *
+     * @param key           The key of the resource to add
+     * @param value         The value of the resource to add
+     * @param netDictionary The dictionary to add the resource in
+     */
+    public SMSAddResource(@NonNull String key, @NonNull String value, @NonNull NetDictionary<String, String> netDictionary) {
+        super(key, value, netDictionary);
+    }
+
+    /**
+     * Adds the key-resource pair to the dictionary, then broadcasts the message
+     */
+    protected void execute() {
+        netDictionary.addResource(key, value);
+        //TODO broadcast
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSInvitePeer.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSInvitePeer.java
@@ -1,0 +1,33 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import androidx.annotation.NonNull;
+
+import com.eis.smslibrary.SMSHandler;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.RequestType;
+
+/**
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSInvitePeer extends com.eis.communication.network.commands.InvitePeer<SMSPeer> {
+
+    /**
+     * Constructor for the SMSInvitePeer command, requires data to work
+     *
+     * @param peerToInvite The SMSPeer to invite to the network
+     */
+    public SMSInvitePeer(@NonNull SMSPeer peerToInvite) {
+        super(peerToInvite);
+    }
+
+    /**
+     * Execute the SMSInvitePeer logic: sends a request to join a network
+     */
+    protected void execute() {
+        String message = RequestType.Invite.asString();
+        SMSMessage messageToSend = new SMSMessage(peerToInvite, message);
+        SMSHandler.getInstance().sendMessage(messageToSend);
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSRemovePeer.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSRemovePeer.java
@@ -1,0 +1,35 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetSubscriberList;
+import com.eis.smslibrary.SMSPeer;
+
+/**
+ * Command to remove a peer from the subscribers
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSRemovePeer extends com.eis.communication.network.commands.RemovePeer<SMSPeer> {
+
+    /**
+     * Constructor for the SMSRemovePeer command, needs the data to operate
+     *
+     * @param peer           The peer to remove from the network
+     * @param netSubscribers The subscribers currently in the network
+     */
+    public SMSRemovePeer(@NonNull SMSPeer peer, @NonNull NetSubscriberList<SMSPeer> netSubscribers) {
+        super(peer, netSubscribers);
+    }
+
+    /**
+     * Removes a peer from the subscribers list and broadcasts it to the net
+     */
+    protected void execute() {
+        netSubscribers.removeSubscriber(peer);
+        //TODO broadcast
+    }
+
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSRemoveResource.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/smsnetcommands/SMSRemoveResource.java
@@ -1,0 +1,33 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetDictionary;
+
+/**
+ * Command to remove a resource from the network dictionary
+ *
+ * @author Edoardo Raimondi
+ * @author Marco Cognolato
+ * @author Giovanni Velludo
+ */
+public class SMSRemoveResource extends com.eis.communication.network.commands.RemoveResource<String, String> {
+
+    /**
+     * Constructor for the SMSRemoveResource command, needs the data to operate
+     *
+     * @param key           The key identifier of the resource to remove
+     * @param netDictionary The dictionary to remove the resource from
+     */
+    public SMSRemoveResource(@NonNull String key, @NonNull NetDictionary<String, String> netDictionary) {
+        super(key, netDictionary);
+    }
+
+    /**
+     * Removes a Resource from the dictionary, then broadcasts it to the net
+     */
+    protected void execute() {
+        netDictionary.removeResource(key);
+        //TODO broadcast
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/BroadcastSenderTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/BroadcastSenderTest.java
@@ -1,0 +1,22 @@
+package com.eis.smsnetwork;
+
+import com.eis.smslibrary.SMSPeer;
+
+import org.junit.Before;
+
+public class BroadcastSenderTest {
+
+    private static final SMSPeer PEER1 = SMSNetSubscriberListTest.PEER1;
+    private static final SMSPeer PEER2 = SMSNetSubscriberListTest.PEER2;
+    private static final SMSPeer PEER3 = SMSNetSubscriberListTest.PEER3;
+
+    private final SMSNetSubscriberList subscribers = new SMSNetSubscriberList();
+
+    @Before
+    public void setup() {
+        subscribers.addSubscriber(PEER1);
+        subscribers.addSubscriber(PEER2);
+        subscribers.addSubscriber(PEER3);
+    }
+
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/SMSNetDictionaryTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/SMSNetDictionaryTest.java
@@ -1,0 +1,82 @@
+package com.eis.smsnetwork;
+
+import com.eis.smsnetwork.SMSNetDictionary;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the SMSNetDictionary class
+ *
+ * @author Marco Cognolato
+ */
+public class SMSNetDictionaryTest {
+
+    private final String KEY1 = "ResourceKey";
+    private final String KEY2 = "OtherKey";
+    private final String INVALID_KEY = "This is not a valid key";
+
+    private final String RESOURCE1 = "This is a valid resource";
+    private final String RESOURCE2 = "This is another valid resource";
+
+    private SMSNetDictionary netDictionary;
+
+    @Before
+    public void setup() {
+        netDictionary = new SMSNetDictionary();
+    }
+
+    @Test
+    public void addResource_getsAdded() {
+        netDictionary.addResource(KEY1, RESOURCE1);
+        assertEquals(netDictionary.getResource(KEY1), RESOURCE1);
+    }
+
+    @Test
+    public void addAnotherResource_getsAdded() {
+        netDictionary.addResource(KEY1, RESOURCE1);
+        netDictionary.addResource(KEY2, RESOURCE2);
+        assertEquals(netDictionary.getResource(KEY1), RESOURCE1);
+        assertEquals(netDictionary.getResource(KEY2), RESOURCE2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addInvalidKey_throws() {
+        netDictionary.addResource(INVALID_KEY, RESOURCE1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getInvalidKey_throws() {
+        netDictionary.getResource(INVALID_KEY);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void removeInvalidKey_throws() {
+        netDictionary.removeResource(INVALID_KEY);
+    }
+
+    @Test
+    public void searchResourceNotPresent_returnsNull() {
+        assertNull(netDictionary.getResource(KEY1));
+    }
+
+    @Test
+    public void searchResourceNotAdded_returnsNull() {
+        netDictionary.addResource(KEY2, RESOURCE1);
+        assertNull(netDictionary.getResource(KEY1));
+    }
+
+    @Test
+    public void removeNonAddedResource_doesNothing() {
+        netDictionary.removeResource(KEY1);
+    }
+
+    @Test
+    public void removeResource_getsRemoved() {
+        netDictionary.addResource(KEY2, RESOURCE1);
+        netDictionary.removeResource(KEY2);
+        assertNull(netDictionary.getResource(KEY2));
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSAddPeerTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSAddPeerTest.java
@@ -1,0 +1,23 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.SMSNetworkManager;
+import com.eis.smsnetwork.smsnetcommands.SMSAddPeer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SMSAddPeerTest {
+
+    private SMSPeer peer = new SMSPeer("+393408140326");
+    private SMSNetworkManager networkManager = new SMSNetworkManager();
+    private SMSAddPeer addPeer = new SMSAddPeer(peer, networkManager.getNetSubscriberList());
+
+    @Test
+    public void execute() {
+        CommandExecutor.execute(addPeer);
+        assertTrue(networkManager.getNetSubscriberList().getSubscribers().contains(peer));
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSAddResourceTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSAddResourceTest.java
@@ -1,0 +1,27 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import com.eis.communication.network.commands.AddResource;
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.smsnetwork.SMSNetworkManager;
+import com.eis.smsnetwork.smsnetcommands.SMSAddResource;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SMSAddResourceTest {
+
+    private SMSNetworkManager networkManager = new SMSNetworkManager();
+
+    private String key = "key";
+    private String value = "value";
+
+    private SMSAddResource addResource = new SMSAddResource(key, value, networkManager.getNetDictionary());
+
+    @Test
+    public void execute() {
+        CommandExecutor.execute(addResource);
+        assertEquals(networkManager.getNetDictionary().getResource(key), value);
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSRemovePeerTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSRemovePeerTest.java
@@ -1,0 +1,39 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import com.eis.communication.network.commands.AddPeer;
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.communication.network.commands.RemovePeer;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.SMSNetworkManager;
+import com.eis.smsnetwork.smsnetcommands.SMSAddPeer;
+import com.eis.smsnetwork.smsnetcommands.SMSRemovePeer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SMSRemovePeerTest {
+
+    private SMSPeer peer1 = new SMSPeer("+393408140326");
+    private SMSPeer peer2 = new SMSPeer("+393408140366");
+
+    private SMSNetworkManager networkManager = new SMSNetworkManager();
+
+    private SMSAddPeer addPeer1 = new SMSAddPeer(peer1, networkManager.getNetSubscriberList());
+    private SMSAddPeer addPeer2 = new SMSAddPeer(peer2, networkManager.getNetSubscriberList());
+
+    private SMSRemovePeer removePeer1 = new SMSRemovePeer(peer1, networkManager.getNetSubscriberList());
+
+    @Before
+    public void setUp(){
+        CommandExecutor.execute(addPeer1);
+        CommandExecutor.execute(addPeer2);
+    }
+
+    @Test
+    public void execute() {
+        CommandExecutor.execute(removePeer1);
+        assertFalse(networkManager.getNetSubscriberList().getSubscribers().contains(peer1));
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSRemoveResourceTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/smsnetcommands/SMSRemoveResourceTest.java
@@ -1,0 +1,45 @@
+package com.eis.smsnetwork.smsnetcommands;
+
+import com.eis.communication.network.commands.AddResource;
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.communication.network.commands.RemoveResource;
+import com.eis.smsnetwork.SMSNetworkManager;
+import com.eis.smsnetwork.smsnetcommands.SMSAddResource;
+import com.eis.smsnetwork.smsnetcommands.SMSRemoveResource;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SMSRemoveResourceTest {
+
+    private SMSNetworkManager networkManager = new SMSNetworkManager();
+
+    private String key1 = "key";
+    private String value1 = "value";
+
+    private String key2 = "lmao";
+    private String value2 = "fuck";
+
+    private SMSAddResource addResource1 = new SMSAddResource(key1, value1, networkManager.getNetDictionary());
+    private SMSAddResource addResource2 = new SMSAddResource(key2, value2, networkManager.getNetDictionary());
+    private SMSRemoveResource removeResource = new SMSRemoveResource(key1, networkManager.getNetDictionary());
+    @Before
+    public void setUp(){
+        CommandExecutor.execute(addResource1);
+        CommandExecutor.execute(addResource2);
+    }
+
+    @Test
+    public void execute1() {
+        CommandExecutor.execute(removeResource);
+        assertNull(networkManager.getNetDictionary().getResource(key1));
+    }
+
+    @Test
+    public void execute2(){
+        CommandExecutor.execute(removeResource);
+        assertNotNull(networkManager.getNetDictionary().getResource(key2));
+    }
+}


### PR DESCRIPTION
### **Premise**
In this pull request, we are proposing the SMS implementation of the more generic Commands that we presented in the previous pull request.
We also completed the first version of the SMSJoinableNetManager, the class that allows the user to decide to enter a network when invited; it extends the more basic SMSNetworkManager class.
An interesting class to analyze is the RequestType, a modified enum used to recognize the incoming SMS messages.
The BroadcastSender, a small class to send messages to all the specified peers.
And a bunch of tests, just to prove you that we are doing them.

### **Main changes**
**1. SMSJoinableNetManager**
This class is triggered by a listener, if activated the network asks the user if he prefers to enter a specific network or not

**2. "SMSCommands"**
. SMSAcceptInvite
. SMSInvitePeer
. SMSAddPeer
. SMSAddResource
. SMSRemovePeer
. SMSRemoveResource
The SMS implementation of the more basic Commands of the previous Pull Request, 

### **What is left to do**
We have to finish the BroadcastReceiver (the SMS messages listener that decode their content) and connect everything.
Non of these classes can be classified as completed, according to your opinion we will decide how to proceed, please let us know if there is some major problem that we missed.

We hope that, without considering the tests, this won't appear as too much code to review, it's pretty modular and a lot of classes shares the same simple structure.
Thank you, and good review.