### PR TITLE
Code review #3

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" value="$USER_HOME$/Documents/javadoc" />
-    <option name="OPTION_SCOPE" value="private" />
+    <option name="OPTION_SCOPE" value="package" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -223,7 +223,7 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 // resources cannot have a backslash as their last character
                 String lastField = fields[fields.length - 1];
                 if (lastField.charAt(lastField.length() - 1) == '\\') {
-                    Log.e(LOG_TAG, "RemoveResource message contains an invalid resource");
+                    Log.e(LOG_TAG, "RemoveResource message contains an invalid key");
                     return;
                 }
                 try {

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -1,0 +1,182 @@
+package com.eis.smsnetwork.broadcast;
+
+import android.util.Log;
+
+import com.eis.communication.network.commands.CommandExecutor;
+import com.eis.smslibrary.SMSManager;
+import com.eis.smsnetwork.RequestType;
+import com.eis.smsnetwork.SMSInvitation;
+import com.eis.smsnetwork.SMSJoinableNetManager;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smslibrary.exceptions.InvalidTelephoneNumberException;
+import com.eis.smslibrary.listeners.SMSReceivedServiceListener;
+import com.eis.smsnetwork.SMSNetDictionary;
+import com.eis.smsnetwork.SMSNetSubscriberList;
+import com.eis.smsnetwork.smsnetcommands.SMSAddPeer;
+
+import java.util.Set;
+
+/**
+ * @author Marco Cognolato, Giovanni Velludo, Enrico Cestaro
+ */
+public class BroadcastReceiver extends SMSReceivedServiceListener {
+
+    private static final int REQUEST_FIELD_END_INDEX = 1;
+    public static final String FIELD_SEPARATOR = "¤";
+    // To allow FIELD_SEPARATOR in keys and resources, we escape it with a backslash when
+    // sending those keys and resources through an SMS. Therefore we only split the message
+    // when FIELD_SEPARATOR is not preceded by a backslash.
+    static final String SEPARATOR_REGEX = "(?<!\\\\)" + FIELD_SEPARATOR;
+
+
+    /**
+     * Receives messages from other peers in the network and acts according to the content of those
+     * messages. Messages are composed of different fields, separated by
+     * {@link BroadcastReceiver#FIELD_SEPARATOR}. {@link BroadcastReceiver#FIELD_SEPARATOR}s
+     * preceded by a backslash do not separate fields.
+     * Field 0 contains the {@link RequestType} of the request contained in this message.
+     * The rest of the message varies depending on the {@link RequestType}:
+     * <ul>
+     * <li>Invite: there are no other fields</li>
+     * <li>AcceptInvitation: there are no other fields</li>
+     * <li>AddPeer: fields from 1 to the last one contain the phone numbers of each
+     * {@link com.eis.smslibrary.SMSPeer} we have to add to our network</li>
+     * <li>QuitNetwork: there are no other fields, because this request can only be sent by the
+     * {@link com.eis.smslibrary.SMSPeer} who wants to be removed</li>
+     * <li>AddResource: starting from 1, fields with odd numbers contain keys, their following
+     * (even)
+     * field contains the corresponding value</li>
+     * <li>RemoveResource: fields from 1 to the last one contain the keys to remove</li>
+     * </ul>
+     *
+     * @param message The message passed by {@link com.eis.smslibrary.SMSReceivedBroadcastReceiver}.
+     */
+    @Override
+    public void onMessageReceived(SMSMessage message) {
+        Log.d("BR_RECEIVER", "Message received: " + message.getPeer() + " " + message.getData());
+        String[] fields = message.getData().split(SEPARATOR_REGEX);
+        RequestType request;
+        try {
+            request = RequestType.get(fields[0]);
+        } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {
+            return;
+        }
+        if (request == null) return;
+        SMSPeer sender = message.getPeer();
+        SMSNetSubscriberList subscribers =
+                (SMSNetSubscriberList) SMSJoinableNetManager.getInstance().getNetSubscriberList();
+        SMSNetDictionary dictionary =
+                (SMSNetDictionary) SMSJoinableNetManager.getInstance().getNetDictionary();
+        boolean senderIsNotSubscriber = !subscribers.getSubscribers().contains(sender);
+
+        switch (request) {
+            case Invite: {
+                if (fields.length > 1) return;
+                SMSJoinableNetManager.getInstance().checkInvitation(new SMSInvitation(sender));
+                break;
+            }
+            case AcceptInvitation: {
+                if (fields.length > 1) return;
+                // Verifying if the sender has been invited to join the network
+                Set<SMSPeer> invitedPeers = SMSJoinableNetManager.getInstance().getInvitedPeers();
+                if (!invitedPeers.contains(sender))
+                    return;
+                invitedPeers.remove(sender);
+
+                // Sending to the invited peer my subscribers list
+                StringBuilder mySubscribers = new StringBuilder(RequestType.AddPeer.asString() +
+                        FIELD_SEPARATOR);
+                for (SMSPeer peerToAdd : subscribers.getSubscribers())
+                    mySubscribers.append(peerToAdd).append(FIELD_SEPARATOR);
+                SMSMessage mySubscribersMessage = new SMSMessage(
+                        sender, mySubscribers.deleteCharAt(mySubscribers.length() - 1).toString());
+                SMSManager.getInstance().sendMessage(mySubscribersMessage);
+
+                // Sending my dictionary to the invited peer
+                String myDictionary = RequestType.AddResource.asString() + FIELD_SEPARATOR +
+                        dictionary.getAllKeyResourcePairsForSMS();
+                SMSMessage myDictionaryMessage = new SMSMessage(sender, myDictionary);
+                SMSManager.getInstance().sendMessage(myDictionaryMessage);
+
+                // Broadcasting to the previous subscribers the new subscriber
+                CommandExecutor.execute(new SMSAddPeer(sender, subscribers));
+                // Updating my local subscribers list
+                subscribers.addSubscriber(sender);
+            }
+            case AddPeer: {
+                if (senderIsNotSubscriber) return;
+                SMSPeer[] peersToAdd;
+                try {
+                    peersToAdd = new SMSPeer[fields.length - REQUEST_FIELD_END_INDEX];
+                } catch (NegativeArraySizeException e) {
+                    return;
+                }
+                try {
+                    for (int i = REQUEST_FIELD_END_INDEX; i < fields.length; i++)
+                        peersToAdd[i - REQUEST_FIELD_END_INDEX] = new SMSPeer(fields[i]);
+                } catch (InvalidTelephoneNumberException | ArrayIndexOutOfBoundsException e) {
+                    return;
+                }
+                for (SMSPeer peer : peersToAdd)
+                    subscribers.addSubscriber(peer);
+                break;
+            }
+            case QuitNetwork: {
+                if (fields.length > 1) return;
+                try {
+                    subscribers.removeSubscriber(sender);
+                } catch (IllegalArgumentException e) {
+                    return;
+                }
+                break;
+            }
+            case AddResource: {
+                // if the number of fields is even, that means not every key will have a
+                // corresponding value, so the message we received is garbage. For example, with 4
+                // fields we'll have: requestType, key, value, key
+                if (senderIsNotSubscriber || fields.length % 2 == 0) return;
+                // the last field is the only one which can possibly contain a backslash as its last
+                // character, if it does then the message we received is garbage because keys and
+                // resources cannot have a backslash as their last character
+                String lastField = fields[fields.length - 1];
+                if (lastField.charAt(lastField.length() - 1) == '\\') return;
+                String[] keys;
+                String[] values;
+                try {
+                    keys = new String[(fields.length - REQUEST_FIELD_END_INDEX) / 2];
+                    values = new String[keys.length];
+                } catch (NegativeArraySizeException e) {
+                    return;
+                }
+                try {
+                    for (int i = 0, j = REQUEST_FIELD_END_INDEX; j < fields.length; i++) {
+                        keys[i] = fields[j++];
+                        values[i] = fields[j++];
+                    }
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    return;
+                }
+                for (int i = 0; i < keys.length; i++) {
+                    dictionary.addResourceFromSMS(keys[i], values[i]);
+                }
+                break;
+            }
+            case RemoveResource: {
+                if (senderIsNotSubscriber) return;
+                // the last field is the only one which can possibly contain a backslash as its last
+                // character, if it does then the message we received is garbage because keys and
+                // resources cannot have a backslash as their last character
+                String lastField = fields[fields.length - 1];
+                if (lastField.charAt(lastField.length() - 1) == '\\') return;
+                try {
+                    for (int i = REQUEST_FIELD_END_INDEX; i < fields.length; i++)
+                        dictionary.removeResourceFromSMS(fields[i]);
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    return;
+                }
+                break;
+            }
+        }
+    }
+}

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -22,7 +22,7 @@ import java.util.Set;
  */
 public class BroadcastReceiver extends SMSReceivedServiceListener {
 
-    private static final int REQUEST_FIELD_END_INDEX = 1;
+    private static final int FIELD_1_INDEX = 1;
     public static final String FIELD_SEPARATOR = "¤";
     // To allow FIELD_SEPARATOR in keys and resources, we escape it with a backslash when
     // sending those keys and resources through an SMS. Therefore we only split the message
@@ -30,23 +30,22 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
     static final String SEPARATOR_REGEX = "(?<!\\\\)" + FIELD_SEPARATOR;
     private static final String LOG_TAG = "BroadcastReceiver";
 
-
     /**
      * Receives messages from other peers in the network and acts according to the content of those
-     * messages. Messages are composed of different fields, separated by
-     * {@link BroadcastReceiver#FIELD_SEPARATOR}. {@link BroadcastReceiver#FIELD_SEPARATOR}s
-     * preceded by a backslash do not separate fields.
-     * Field 0 contains the {@link RequestType} of the request contained in this message.
-     * The rest of the message varies depending on the {@link RequestType}:
+     * messages. Messages are composed of different fields, separated by {@link
+     * BroadcastReceiver#FIELD_SEPARATOR}. {@link BroadcastReceiver#FIELD_SEPARATOR}s preceded by a
+     * backslash do not separate fields. Field 0 contains the {@link RequestType} of the request
+     * contained in this message. The rest of the message varies depending on the {@link
+     * RequestType}:
      * <ul>
      * <li>{@code Invite}: there are no other fields</li>
      * <li>{@code AcceptInvitation}: there are no other fields</li>
      * <li>{@code AddPeer}: fields from 1 to the last one contain the phone numbers of each
      * {@link com.eis.smslibrary.SMSPeer} we have to add to our network</li>
-     * <li>{@code QuitNetwork}: there are no other fields, because this request can only be sent by the
-     * {@link com.eis.smslibrary.SMSPeer} who wants to be removed</li>
-     * <li>{@code AddResource}: starting from 1, fields with odd numbers contain keys, their following
-     * (even) field contains the corresponding value</li>
+     * <li>{@code QuitNetwork}: there are no other fields, because this request can only be sent
+     * by the {@link com.eis.smslibrary.SMSPeer} who wants to be removed</li>
+     * <li>{@code AddResource}: starting from 1, fields with odd numbers contain keys, their
+     * following (even) field contains the corresponding value</li>
      * <li>{@code RemoveResource}: fields from 1 to the last one contain the keys to remove</li>
      * </ul>
      *
@@ -57,17 +56,9 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
         Log.d(LOG_TAG, "Message received: " + message.getPeer() + " " + message.getData());
         String[] fields = message.getData().split(SEPARATOR_REGEX);
         RequestType request;
-        try {
-            request = RequestType.get(fields[0]);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            Log.e(LOG_TAG, "Message has no fields");
-            return;
-        } catch (NullPointerException e) {
-            Log.e(LOG_TAG, "Message has invalid RequestType");
-            return;
-        }
+        request = RequestType.get(fields[0]);
         if (request == null) {
-            Log.e(LOG_TAG, "Message has empty field 0");
+            Log.e(LOG_TAG, "Message has empty field 0 or invalid RequestType");
             return;
         }
         SMSPeer sender = message.getPeer();
@@ -80,8 +71,9 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
         switch (request) {
             case Invite: {
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should " +
-                            "have been only 1");
+                    Log.e(LOG_TAG,
+                            "Message has " + fields.length + " fields, but there should have" +
+                                    " been only 1");
                     return;
                 }
                 SMSJoinableNetManager.getInstance().checkInvitation(new SMSInvitation(sender));
@@ -89,8 +81,9 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
             }
             case AcceptInvitation: {
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should " +
-                            "have been only 1");
+                    Log.e(LOG_TAG,
+                            "Message has " + fields.length + " fields, but there should have" +
+                                    " been only 1");
                     return;
                 }
                 // Verifying if the sender has been invited to join the network
@@ -102,8 +95,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 invitedPeers.remove(sender);
 
                 // Sending to the invited peer my subscribers list
-                StringBuilder mySubscribers = new StringBuilder(RequestType.AddPeer.asString() +
-                        FIELD_SEPARATOR);
+                StringBuilder mySubscribers =
+                        new StringBuilder(RequestType.AddPeer.asString() + FIELD_SEPARATOR);
                 for (SMSPeer peerToAdd : subscribers.getSubscribers())
                     mySubscribers.append(peerToAdd).append(FIELD_SEPARATOR);
                 SMSMessage mySubscribersMessage = new SMSMessage(
@@ -114,8 +107,9 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 SMSManager.getInstance().sendMessage(mySubscribersMessage);
 
                 // Sending my dictionary to the invited peer
-                String myDictionary = RequestType.AddResource.asString() + FIELD_SEPARATOR +
-                        dictionary.getAllKeyResourcePairsForSMS();
+                String myDictionary =
+                        RequestType.AddResource.asString() + FIELD_SEPARATOR +
+                                dictionary.getAllKeyResourcePairsForSMS();
                 SMSMessage myDictionaryMessage = new SMSMessage(sender, myDictionary);
                 SMSManager.getInstance().sendMessage(myDictionaryMessage);
 
@@ -130,22 +124,12 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     return;
                 }
                 SMSPeer[] peersToAdd;
+                peersToAdd = new SMSPeer[fields.length - FIELD_1_INDEX];
                 try {
-                    peersToAdd = new SMSPeer[fields.length - REQUEST_FIELD_END_INDEX];
-                } catch (NegativeArraySizeException e) {
-                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any " +
-                            "peers to be added");
-                    return;
-                }
-                try {
-                    for (int i = REQUEST_FIELD_END_INDEX; i < fields.length; i++)
-                        peersToAdd[i - REQUEST_FIELD_END_INDEX] = new SMSPeer(fields[i]);
+                    for (int i = FIELD_1_INDEX; i < fields.length; i++)
+                        peersToAdd[i - FIELD_1_INDEX] = new SMSPeer(fields[i]);
                 } catch (InvalidTelephoneNumberException e) {
                     Log.e(LOG_TAG, "Peers to be added have an invalid phone number");
-                    return;
-                } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any " +
-                            "peers to be added");
                     return;
                 }
                 for (SMSPeer peer : peersToAdd)
@@ -153,18 +137,17 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 break;
             }
             case QuitNetwork: {
+                if (senderIsNotSubscriber) {
+                    Log.e(LOG_TAG, "QuitNetwork received by peer who's not part of our network");
+                    return;
+                }
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, there should have " +
-                            "been only 1");
+                    Log.e(LOG_TAG,
+                            "Message has " + fields.length + " fields, there should have " +
+                                    "been only 1");
                     return;
                 }
-                try {
-                    subscribers.removeSubscriber(sender);
-                } catch (IllegalArgumentException e) {
-                    Log.e(LOG_TAG, "The subscriber asking to be removed from the network is not " +
-                            "part of the network");
-                    return;
-                }
+                subscribers.removeSubscriber(sender);
                 break;
             }
             case AddResource: {
@@ -188,28 +171,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     Log.e(LOG_TAG, "AddResource message contains an invalid resource");
                     return;
                 }
-                String[] keys;
-                String[] values;
-                try {
-                    keys = new String[(fields.length - REQUEST_FIELD_END_INDEX) / 2];
-                    values = new String[keys.length];
-                } catch (NegativeArraySizeException e) {
-                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain " +
-                            "any keys nor resources");
-                    return;
-                }
-                try {
-                    for (int i = 0, j = REQUEST_FIELD_END_INDEX; j < fields.length; i++) {
-                        keys[i] = fields[j++];
-                        values[i] = fields[j++];
-                    }
-                } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain " +
-                            "any keys nor resources");
-                    return;
-                }
-                for (int i = 0; i < keys.length; i++) {
-                    dictionary.addResourceFromSMS(keys[i], values[i]);
+                for (int i = FIELD_1_INDEX; i < fields.length;) {
+                    dictionary.addResourceFromSMS(fields[i++], fields[i++]);
                 }
                 break;
             }
@@ -226,14 +189,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     Log.e(LOG_TAG, "RemoveResource message contains an invalid key");
                     return;
                 }
-                try {
-                    for (int i = REQUEST_FIELD_END_INDEX; i < fields.length; i++)
-                        dictionary.removeResourceFromSMS(fields[i]);
-                } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is RemoveResource, but the message doesn't " +
-                            "contain any keys of resources to be removed");
-                    return;
-                }
+                for (int i = FIELD_1_INDEX; i < fields.length; i++)
+                    dictionary.removeResourceFromSMS(fields[i]);
                 break;
             }
         }

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -90,6 +90,9 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 for (SMSPeer peerToAdd : subscribers.getSubscribers())
                     mySubscribers.append(peerToAdd).append(FIELD_SEPARATOR);
                 SMSMessage mySubscribersMessage = new SMSMessage(
+                        // we remove the last character in mySubscribers because it's a
+                        // FIELD_SEPARATOR, and there's no need for it since there can't be any
+                        // more fields after the last character of the message
                         sender, mySubscribers.deleteCharAt(mySubscribers.length() - 1).toString());
                 SMSManager.getInstance().sendMessage(mySubscribersMessage);
 

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -80,7 +80,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
         switch (request) {
             case Invite: {
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should have been only 1");
+                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should " +
+                            "have been only 1");
                     return;
                 }
                 SMSJoinableNetManager.getInstance().checkInvitation(new SMSInvitation(sender));
@@ -88,7 +89,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
             }
             case AcceptInvitation: {
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should have been only 1");
+                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, but there should " +
+                            "have been only 1");
                     return;
                 }
                 // Verifying if the sender has been invited to join the network
@@ -131,7 +133,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 try {
                     peersToAdd = new SMSPeer[fields.length - REQUEST_FIELD_END_INDEX];
                 } catch (NegativeArraySizeException e) {
-                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any peers to be added");
+                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any " +
+                            "peers to be added");
                     return;
                 }
                 try {
@@ -141,7 +144,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     Log.e(LOG_TAG, "Peers to be added have an invalid phone number");
                     return;
                 } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any peers to be added");
+                    Log.e(LOG_TAG, "RequestType is AddPeer, but the message doesn't contain any " +
+                            "peers to be added");
                     return;
                 }
                 for (SMSPeer peer : peersToAdd)
@@ -150,13 +154,15 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
             }
             case QuitNetwork: {
                 if (fields.length > 1) {
-                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, there should have been only 1");
+                    Log.e(LOG_TAG, "Message has " + fields.length + " fields, there should have " +
+                            "been only 1");
                     return;
                 }
                 try {
                     subscribers.removeSubscriber(sender);
                 } catch (IllegalArgumentException e) {
-                    Log.e(LOG_TAG, "The subscriber asking to be removed from the network is not part of the network");
+                    Log.e(LOG_TAG, "The subscriber asking to be removed from the network is not " +
+                            "part of the network");
                     return;
                 }
                 break;
@@ -170,7 +176,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                 // corresponding value, so the message we received is garbage. For example, with 4
                 // fields we'll have: requestType, key, value, key
                 if (fields.length % 2 == 0) {
-                    Log.e(LOG_TAG, "AddResource message contains a key with no corresponding resource");
+                    Log.e(LOG_TAG, "AddResource message contains a key with no corresponding " +
+                            "resource");
                     return;
                 }
                 // the last field is the only one which can possibly contain a backslash as its last
@@ -187,7 +194,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     keys = new String[(fields.length - REQUEST_FIELD_END_INDEX) / 2];
                     values = new String[keys.length];
                 } catch (NegativeArraySizeException e) {
-                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain any keys nor resources");
+                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain " +
+                            "any keys nor resources");
                     return;
                 }
                 try {
@@ -196,7 +204,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                         values[i] = fields[j++];
                     }
                 } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain any keys nor resources");
+                    Log.e(LOG_TAG, "RequestType is AddResource, but the message doesn't contain " +
+                            "any keys nor resources");
                     return;
                 }
                 for (int i = 0; i < keys.length; i++) {
@@ -221,7 +230,8 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
                     for (int i = REQUEST_FIELD_END_INDEX; i < fields.length; i++)
                         dictionary.removeResourceFromSMS(fields[i]);
                 } catch (ArrayIndexOutOfBoundsException e) {
-                    Log.e(LOG_TAG, "RequestType is RemoveResource, but the message doesn't contain any keys of resources to be removed");
+                    Log.e(LOG_TAG, "RequestType is RemoveResource, but the message doesn't " +
+                            "contain any keys of resources to be removed");
                     return;
                 }
                 break;

--- a/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
+++ b/networklibrary/src/main/java/com/eis/smsnetwork/broadcast/BroadcastReceiver.java
@@ -39,15 +39,15 @@ public class BroadcastReceiver extends SMSReceivedServiceListener {
      * Field 0 contains the {@link RequestType} of the request contained in this message.
      * The rest of the message varies depending on the {@link RequestType}:
      * <ul>
-     * <li>Invite: there are no other fields</li>
-     * <li>AcceptInvitation: there are no other fields</li>
-     * <li>AddPeer: fields from 1 to the last one contain the phone numbers of each
+     * <li>{@code Invite}: there are no other fields</li>
+     * <li>{@code AcceptInvitation}: there are no other fields</li>
+     * <li>{@code AddPeer}: fields from 1 to the last one contain the phone numbers of each
      * {@link com.eis.smslibrary.SMSPeer} we have to add to our network</li>
-     * <li>QuitNetwork: there are no other fields, because this request can only be sent by the
+     * <li>{@code QuitNetwork}: there are no other fields, because this request can only be sent by the
      * {@link com.eis.smslibrary.SMSPeer} who wants to be removed</li>
-     * <li>AddResource: starting from 1, fields with odd numbers contain keys, their following
+     * <li>{@code AddResource}: starting from 1, fields with odd numbers contain keys, their following
      * (even) field contains the corresponding value</li>
-     * <li>RemoveResource: fields from 1 to the last one contain the keys to remove</li>
+     * <li>{@code RemoveResource}: fields from 1 to the last one contain the keys to remove</li>
      * </ul>
      *
      * @param message The message passed by {@link com.eis.smslibrary.SMSReceivedBroadcastReceiver}.

--- a/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
@@ -53,6 +53,11 @@ public class BroadcastReceiverTest {
         when(Log.e(anyString(), anyString())).thenReturn(0);
     }
 
+    /**
+     * Tests whether {@link BroadcastReceiver#SEPARATOR_REGEX} correctly splits fields in
+     * received messages, that is whenever a non escaped
+     * {@link BroadcastReceiver#FIELD_SEPARATOR} is found.
+     */
     @Test
     public void separatorRegex() {
         String message = "è" + FIELD_SEPARATOR + "greeting" + FIELD_SEPARATOR + "howdily\\" +
@@ -76,6 +81,9 @@ public class BroadcastReceiverTest {
         Assert.assertArrayEquals(expectedFields, fields);
     }
 
+    /**
+     * Tests whether a message not meant for our dictionary is ignored.
+     */
     @Test
     public void onMessageReceived_garbage_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -93,6 +101,10 @@ public class BroadcastReceiverTest {
         SMSJoinableNetManager.getInstance();
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#Invite} containing some unneeded
+     * additional fields is ignored.
+     */
     @Test
     public void onMessageReceived_inviteWithGarbage_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -110,6 +122,10 @@ public class BroadcastReceiverTest {
         verify(mockManager, never()).checkInvitation(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#Invite} and no additional fields is
+     * correctly processed.
+     */
     @Test
     public void onMessageReceived_correctInvite() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -132,6 +148,10 @@ public class BroadcastReceiverTest {
         Assert.assertEquals(sender, invitationCaptor.getValue().getInviterPeer());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AcceptInvitation} received by a peer who
+     * wasn't invited is ignored.
+     */
     @Test
     public void onMessageReceived_acceptInvitationFromUninvited_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -160,6 +180,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers, never()).addSubscriber(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AcceptInvitation} containing unneeded
+     * additional fields is ignored.
+     */
     @Test
     public void onMessageReceived_acceptInvitationWithGarbage_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -189,6 +213,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers, never()).addSubscriber(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AcceptInvitation} and no additional fields
+     * from a peer who was invited is correctly processed.
+     */
     @Test
     public void onMessageReceived_correctAcceptInvitation() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -200,15 +228,19 @@ public class BroadcastReceiverTest {
         subscribersSet.add(subscriber);
         Set<SMSPeer> invitedPeers = new HashSet<>();
         invitedPeers.add(sender);
-        String expectedMySubscribersText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + subscriber;
-        String expectedMyDictionaryText = RequestType.AddResource.asString() + FIELD_SEPARATOR + "Key¤This is a valid resource¤OtherKey¤This is another valid resource";
-        String expectedAddPeerTextForSubscribers = RequestType.AddPeer.asString() + FIELD_SEPARATOR + sender;
+        String expectedMySubscribersText =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + subscriber;
+        String expectedMyDictionaryText = RequestType.AddResource.asString() + FIELD_SEPARATOR +
+                "Key¤This is a valid resource¤OtherKey¤This is another valid resource";
+        String expectedAddPeerTextForSubscribers =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + sender;
 
         SMSManager mockSMSManager = mock(SMSManager.class);
         SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
         when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
         SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
-        when(mockDictionary.getAllKeyResourcePairsForSMS()).thenReturn("Key¤This is a valid resource¤OtherKey¤This is another valid resource");
+        when(mockDictionary.getAllKeyResourcePairsForSMS()).thenReturn("Key¤This is a valid " +
+                "resource¤OtherKey¤This is another valid resource");
         SMSJoinableNetManager mockNetworkManager = mock(SMSJoinableNetManager.class);
         when(mockNetworkManager.getNetSubscriberList()).thenReturn(mockSubscribers);
         when(mockNetworkManager.getNetDictionary()).thenReturn(mockDictionary);
@@ -221,14 +253,21 @@ public class BroadcastReceiverTest {
         instance.onMessageReceived(correctMessage);
         verify(mockSMSManager, times(3)).sendMessage(messageCaptor.capture());
         Assert.assertEquals(sender, messageCaptor.getAllValues().get(0).getPeer());
-        Assert.assertEquals(expectedMySubscribersText, messageCaptor.getAllValues().get(0).getData());
+        Assert.assertEquals(expectedMySubscribersText,
+                messageCaptor.getAllValues().get(0).getData());
         Assert.assertEquals(sender, messageCaptor.getAllValues().get(1).getPeer());
-        Assert.assertEquals(expectedMyDictionaryText, messageCaptor.getAllValues().get(1).getData());
+        Assert.assertEquals(expectedMyDictionaryText,
+                messageCaptor.getAllValues().get(1).getData());
         Assert.assertEquals(subscriber, messageCaptor.getAllValues().get(2).getPeer());
-        Assert.assertEquals(expectedAddPeerTextForSubscribers, messageCaptor.getAllValues().get(2).getData());
+        Assert.assertEquals(expectedAddPeerTextForSubscribers,
+                messageCaptor.getAllValues().get(2).getData());
         verify(mockSubscribers, times(2)).addSubscriber(sender);
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#QuitNetwork} and unneeded additional
+     * fields is ignored.
+     */
     @Test
     public void onMessageReceived_quitNetworkWithGarbage_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -250,6 +289,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers, never()).removeSubscriber(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#QuitNetwork} and no additional fields is
+     * correctly processed.
+     */
     @Test
     public void onMessageReceived_correctQuitNetwork() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -271,6 +314,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers).removeSubscriber(sender);
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AddPeer} from a peer who's not part of our
+     * network is ignored.
+     */
     @Test
     public void onMessageReceived_addPeerFromNonSubscriber_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -292,6 +339,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers, never()).addSubscriber(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AddPeer} containing an invalid phone
+     * number is ignored.
+     */
     @Test
     public void onMessageReceived_addPeerWithWrongNumber_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -314,6 +365,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers, never()).addSubscriber(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AddPeer} and proper formatting is
+     * correctly processed.
+     */
     @Test
     public void onMessageReceived_correctAddPeer() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -337,6 +392,10 @@ public class BroadcastReceiverTest {
         verify(mockSubscribers).addSubscriber(new SMSPeer("+39333812123"));
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AddResource} and containing no
+     * key-resource pairs is ignored.
+     */
     @Test
     public void onMessageReceived_addResourceWithNoResources_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -360,6 +419,10 @@ public class BroadcastReceiverTest {
         verify(mockDictionary, never()).addResourceFromSMS(any(), any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#AddResource} and proper formatting is
+     * correctly processed.
+     */
     @Test
     public void onMessageReceived_correctAddResource() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -385,6 +448,10 @@ public class BroadcastReceiverTest {
         verify(mockDictionary).addResourceFromSMS("the book is", "under the table");
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#RemoveResource} and no keys of the
+     * resources to remove is ignored.
+     */
     @Test
     public void onMessageReceived_removeResourceWithNoResources_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
@@ -408,6 +475,10 @@ public class BroadcastReceiverTest {
         verify(mockDictionary, never()).removeResourceFromSMS(any());
     }
 
+    /**
+     * Tests whether a message with {@link RequestType#RemoveResource} and proper formatting is
+     * correctly processed.
+     */
     @Test
     public void onMessageReceived_correctRemoveResource() {
         BroadcastReceiver instance = new BroadcastReceiver();

--- a/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
@@ -50,6 +50,7 @@ public class BroadcastReceiverTest {
     public void setUp() {
         PowerMockito.mockStatic(Log.class);
         when(Log.d(anyString(), anyString())).thenReturn(0);
+        when(Log.e(anyString(), anyString())).thenReturn(0);
     }
 
     @Test

--- a/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
@@ -1,0 +1,433 @@
+package com.eis.smsnetwork.broadcast;
+
+import android.util.Log;
+
+import com.eis.smslibrary.SMSManager;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.RequestType;
+import com.eis.smsnetwork.SMSInvitation;
+import com.eis.smsnetwork.SMSJoinableNetManager;
+import com.eis.smsnetwork.SMSNetDictionary;
+import com.eis.smsnetwork.SMSNetSubscriberList;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static com.eis.smsnetwork.broadcast.BroadcastReceiver.FIELD_SEPARATOR;
+
+/**
+ * @author Giovanni Velludo
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SMSJoinableNetManager.class, SMSManager.class, Log.class})
+public class BroadcastReceiverTest {
+
+    @Captor
+    ArgumentCaptor<SMSInvitation> invitationCaptor;
+
+    @Captor
+    ArgumentCaptor<SMSMessage> messageCaptor;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Log.class);
+        when(Log.d(anyString(), anyString())).thenReturn(0);
+    }
+
+    @Test
+    public void separatorRegex() {
+        String message = "è" + FIELD_SEPARATOR + "greeting" + FIELD_SEPARATOR + "howdily\\" +
+                FIELD_SEPARATOR + "doodily" + FIELD_SEPARATOR + "tree" + FIELD_SEPARATOR + "pinus\\"
+                + FIELD_SEPARATOR + "pinaster\\" + FIELD_SEPARATOR;
+        String[] expectedFields = {"è", "greeting", "howdily\\" + FIELD_SEPARATOR + "doodily",
+                "tree", "pinus" + "\\" + FIELD_SEPARATOR + "pinaster\\" + FIELD_SEPARATOR};
+        String[] fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
+        Assert.assertArrayEquals(expectedFields, fields);
+
+        message = "\\" + FIELD_SEPARATOR + "\\" + FIELD_SEPARATOR + FIELD_SEPARATOR + "\\hello";
+        expectedFields = new String[]{"\\" + FIELD_SEPARATOR + "\\" + FIELD_SEPARATOR, "\\hello"};
+        fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
+        Assert.assertArrayEquals(expectedFields, fields);
+
+        message = "word" + FIELD_SEPARATOR + "\\\\" + FIELD_SEPARATOR + "word" + FIELD_SEPARATOR +
+                "\\" + FIELD_SEPARATOR + "word";
+        expectedFields = new String[]{"word", "\\\\" + FIELD_SEPARATOR + "word",
+                "\\" + FIELD_SEPARATOR + "word"};
+        fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
+        Assert.assertArrayEquals(expectedFields, fields);
+    }
+
+    @Test
+    public void onMessageReceived_garbage_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSMessage garbage = new SMSMessage(sender, "aidsajfksda;ds");
+
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(new SMSNetSubscriberList());
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbage);
+        PowerMockito.verifyStatic(never());
+        SMSJoinableNetManager.getInstance();
+    }
+
+    @Test
+    public void onMessageReceived_inviteWithGarbage_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.Invite.asString() + ">";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(new SMSNetSubscriberList());
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockManager, never()).checkInvitation(any());
+    }
+
+    @Test
+    public void onMessageReceived_correctInvite() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText = RequestType.Invite.asString();
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockManager).checkInvitation(invitationCaptor.capture());
+        Assert.assertEquals(sender, invitationCaptor.getValue().getInviterPeer());
+    }
+
+    @Test
+    public void onMessageReceived_acceptInvitationFromUninvited_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSPeer subscriber = new SMSPeer("+393332734121");
+        String correctText = RequestType.AcceptInvitation.asString();
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(subscriber);
+        Set<SMSPeer> invitedPeers = new HashSet<>();
+
+        SMSManager mockSMSManager = mock(SMSManager.class);
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockNetworkManager = mock(SMSJoinableNetManager.class);
+        when(mockNetworkManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockNetworkManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        when(mockNetworkManager.getInvitedPeers()).thenReturn(invitedPeers);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockNetworkManager);
+        PowerMockito.mockStatic(SMSManager.class);
+        when(SMSManager.getInstance()).thenReturn(mockSMSManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockSMSManager, never()).sendMessage(any());
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    @Test
+    public void onMessageReceived_acceptInvitationWithGarbage_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSPeer subscriber = new SMSPeer("+393332734121");
+        String garbageText = RequestType.AcceptInvitation.asString() + "P";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(subscriber);
+        Set<SMSPeer> invitedPeers = new HashSet<>();
+        invitedPeers.add(sender);
+
+        SMSManager mockSMSManager = mock(SMSManager.class);
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockNetworkManager = mock(SMSJoinableNetManager.class);
+        when(mockNetworkManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockNetworkManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        when(mockNetworkManager.getInvitedPeers()).thenReturn(invitedPeers);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockNetworkManager);
+        PowerMockito.mockStatic(SMSManager.class);
+        when(SMSManager.getInstance()).thenReturn(mockSMSManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSMSManager, never()).sendMessage(any());
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    @Test
+    public void onMessageReceived_correctAcceptInvitation() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSPeer subscriber = new SMSPeer("+393332734121");
+        String correctText = RequestType.AcceptInvitation.asString();
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(subscriber);
+        Set<SMSPeer> invitedPeers = new HashSet<>();
+        invitedPeers.add(sender);
+        String expectedMySubscribersText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + subscriber;
+        String expectedMyDictionaryText = RequestType.AddResource.asString() + FIELD_SEPARATOR + "Key¤This is a valid resource¤OtherKey¤This is another valid resource";
+        String expectedAddPeerTextForSubscribers = RequestType.AddPeer.asString() + FIELD_SEPARATOR + sender;
+
+        SMSManager mockSMSManager = mock(SMSManager.class);
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        when(mockDictionary.getAllKeyResourcePairsForSMS()).thenReturn("Key¤This is a valid resource¤OtherKey¤This is another valid resource");
+        SMSJoinableNetManager mockNetworkManager = mock(SMSJoinableNetManager.class);
+        when(mockNetworkManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockNetworkManager.getNetDictionary()).thenReturn(mockDictionary);
+        when(mockNetworkManager.getInvitedPeers()).thenReturn(invitedPeers);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockNetworkManager);
+        PowerMockito.mockStatic(SMSManager.class);
+        when(SMSManager.getInstance()).thenReturn(mockSMSManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockSMSManager, times(3)).sendMessage(messageCaptor.capture());
+        Assert.assertEquals(sender, messageCaptor.getAllValues().get(0).getPeer());
+        Assert.assertEquals(expectedMySubscribersText, messageCaptor.getAllValues().get(0).getData());
+        Assert.assertEquals(sender, messageCaptor.getAllValues().get(1).getPeer());
+        Assert.assertEquals(expectedMyDictionaryText, messageCaptor.getAllValues().get(1).getData());
+        Assert.assertEquals(subscriber, messageCaptor.getAllValues().get(2).getPeer());
+        Assert.assertEquals(expectedAddPeerTextForSubscribers, messageCaptor.getAllValues().get(2).getData());
+        verify(mockSubscribers, times(2)).addSubscriber(sender);
+    }
+
+    @Test
+    public void onMessageReceived_quitNetworkWithGarbage_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.QuitNetwork.asString() + ">";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).removeSubscriber(any());
+    }
+
+    @Test
+    public void onMessageReceived_correctQuitNetwork() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText = RequestType.QuitNetwork.asString();
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockSubscribers).removeSubscriber(sender);
+    }
+
+    @Test
+    public void onMessageReceived_addPeerFromNonSubscriber_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
+                FIELD_SEPARATOR + "+393338512123";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    @Test
+    public void onMessageReceived_addPeerWithWrongNumber_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
+                FIELD_SEPARATOR + "+0000333812123";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    @Test
+    public void onMessageReceived_correctAddPeer() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
+                FIELD_SEPARATOR + "+39333812123";
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockSubscribers).addSubscriber(new SMSPeer("+393478512584"));
+        verify(mockSubscribers).addSubscriber(new SMSPeer("+39333812123"));
+    }
+
+    @Test
+    public void onMessageReceived_addResourceWithNoResources_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.AddResource.asString();
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
+        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
+    }
+
+    @Test
+    public void onMessageReceived_correctAddResource() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText = RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is " +
+                "on" + FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is" +
+                FIELD_SEPARATOR + "under the table";
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockDictionary).addResourceFromSMS("the cat is on", "the table");
+        verify(mockDictionary).addResourceFromSMS("the book is", "under the table");
+    }
+
+    @Test
+    public void onMessageReceived_removeResourceWithNoResources_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.RemoveResource.asString();
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).removeResourceFromSMS(any());
+        verify(mockDictionary, never()).removeResourceFromSMS(any());
+    }
+
+    @Test
+    public void onMessageReceived_correctRemoveResource() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText = RequestType.RemoveResource.asString() + FIELD_SEPARATOR + "the cat " +
+                "is on" + FIELD_SEPARATOR + "the table";
+        SMSMessage correctMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(correctMessage);
+        verify(mockDictionary).removeResourceFromSMS("the cat is on");
+        verify(mockDictionary).removeResourceFromSMS("the table");
+    }
+}

--- a/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
@@ -416,7 +416,6 @@ public class BroadcastReceiverTest {
 
         instance.onMessageReceived(garbageMessage);
         verify(mockDictionary, never()).addResourceFromSMS(any(), any());
-        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
     }
 
     /**
@@ -471,7 +470,6 @@ public class BroadcastReceiverTest {
         when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
 
         instance.onMessageReceived(garbageMessage);
-        verify(mockDictionary, never()).removeResourceFromSMS(any());
         verify(mockDictionary, never()).removeResourceFromSMS(any());
     }
 

--- a/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
+++ b/networklibrary/src/test/java/com/eis/smsnetwork/broadcast/BroadcastReceiverTest.java
@@ -54,15 +54,15 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether {@link BroadcastReceiver#SEPARATOR_REGEX} correctly splits fields in
-     * received messages, that is whenever a non escaped
-     * {@link BroadcastReceiver#FIELD_SEPARATOR} is found.
+     * Tests whether {@link BroadcastReceiver#SEPARATOR_REGEX} correctly splits fields in received
+     * messages, that is whenever a non escaped {@link BroadcastReceiver#FIELD_SEPARATOR} is found.
      */
     @Test
     public void separatorRegex() {
-        String message = "è" + FIELD_SEPARATOR + "greeting" + FIELD_SEPARATOR + "howdily\\" +
-                FIELD_SEPARATOR + "doodily" + FIELD_SEPARATOR + "tree" + FIELD_SEPARATOR + "pinus\\"
-                + FIELD_SEPARATOR + "pinaster\\" + FIELD_SEPARATOR;
+        String message =
+                "è" + FIELD_SEPARATOR + "greeting" + FIELD_SEPARATOR + "howdily\\" + FIELD_SEPARATOR
+                        + "doodily" + FIELD_SEPARATOR + "tree" + FIELD_SEPARATOR + "pinus\\" +
+                        FIELD_SEPARATOR + "pinaster\\" + FIELD_SEPARATOR;
         String[] expectedFields = {"è", "greeting", "howdily\\" + FIELD_SEPARATOR + "doodily",
                 "tree", "pinus" + "\\" + FIELD_SEPARATOR + "pinaster\\" + FIELD_SEPARATOR};
         String[] fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
@@ -73,8 +73,9 @@ public class BroadcastReceiverTest {
         fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
         Assert.assertArrayEquals(expectedFields, fields);
 
-        message = "word" + FIELD_SEPARATOR + "\\\\" + FIELD_SEPARATOR + "word" + FIELD_SEPARATOR +
-                "\\" + FIELD_SEPARATOR + "word";
+        message =
+                "word" + FIELD_SEPARATOR + "\\\\" + FIELD_SEPARATOR + "word" + FIELD_SEPARATOR +
+                        "\\" + FIELD_SEPARATOR + "word";
         expectedFields = new String[]{"word", "\\\\" + FIELD_SEPARATOR + "word",
                 "\\" + FIELD_SEPARATOR + "word"};
         fields = message.split(BroadcastReceiver.SEPARATOR_REGEX);
@@ -102,8 +103,28 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#Invite} containing some unneeded
-     * additional fields is ignored.
+     * Tests whether an empty message is ignored.
+     */
+    @Test
+    public void onMessageReceived_emptyMessage_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSMessage garbage = new SMSMessage(sender, "");
+
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(new SMSNetSubscriberList());
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbage);
+        PowerMockito.verifyStatic(never());
+        SMSJoinableNetManager.getInstance();
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#Invite} containing some unneeded additional
+     * characters is ignored.
      */
     @Test
     public void onMessageReceived_inviteWithGarbage_isIgnored() {
@@ -123,8 +144,29 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#Invite} and no additional fields is
-     * correctly processed.
+     * Tests whether a message with {@link RequestType#Invite} containing unneeded additional fields
+     * is ignored.
+     */
+    @Test
+    public void onMessageReceived_inviteWithUnneededFields_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.Invite.asString() + FIELD_SEPARATOR + ">";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(new SMSNetSubscriberList());
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockManager, never()).checkInvitation(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#Invite} and no additional fields is correctly
+     * processed.
      */
     @Test
     public void onMessageReceived_correctInvite() {
@@ -182,7 +224,7 @@ public class BroadcastReceiverTest {
 
     /**
      * Tests whether a message with {@link RequestType#AcceptInvitation} containing unneeded
-     * additional fields is ignored.
+     * additional characters is ignored.
      */
     @Test
     public void onMessageReceived_acceptInvitationWithGarbage_isIgnored() {
@@ -190,6 +232,39 @@ public class BroadcastReceiverTest {
         SMSPeer sender = new SMSPeer("+393492794133");
         SMSPeer subscriber = new SMSPeer("+393332734121");
         String garbageText = RequestType.AcceptInvitation.asString() + "P";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(subscriber);
+        Set<SMSPeer> invitedPeers = new HashSet<>();
+        invitedPeers.add(sender);
+
+        SMSManager mockSMSManager = mock(SMSManager.class);
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockNetworkManager = mock(SMSJoinableNetManager.class);
+        when(mockNetworkManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockNetworkManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        when(mockNetworkManager.getInvitedPeers()).thenReturn(invitedPeers);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockNetworkManager);
+        PowerMockito.mockStatic(SMSManager.class);
+        when(SMSManager.getInstance()).thenReturn(mockSMSManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSMSManager, never()).sendMessage(any());
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#AcceptInvitation} containing unneeded
+     * additional fields is ignored.
+     */
+    @Test
+    public void onMessageReceived_acceptInvitationWithUnneededFields_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        SMSPeer subscriber = new SMSPeer("+393332734121");
+        String garbageText = RequestType.AcceptInvitation.asString() + FIELD_SEPARATOR + "P";
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(subscriber);
@@ -266,7 +341,7 @@ public class BroadcastReceiverTest {
 
     /**
      * Tests whether a message with {@link RequestType#QuitNetwork} and unneeded additional
-     * fields is ignored.
+     * characters is ignored.
      */
     @Test
     public void onMessageReceived_quitNetworkWithGarbage_isIgnored() {
@@ -276,6 +351,55 @@ public class BroadcastReceiverTest {
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).removeSubscriber(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#QuitNetwork} and unneeded additional fields
+     * is ignored.
+     */
+    @Test
+    public void onMessageReceived_quitNetworkWithUnneededFields_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.QuitNetwork.asString() + FIELD_SEPARATOR + ">";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).removeSubscriber(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#QuitNetwork} coming from somebody who's not a
+     * subscriber is ignored.
+     */
+    @Test
+    public void onMessageReceived_quitNetworkFromNonSubscriber_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText = RequestType.QuitNetwork.asString() + FIELD_SEPARATOR + ">";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
 
         SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
         when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
@@ -322,8 +446,9 @@ public class BroadcastReceiverTest {
     public void onMessageReceived_addPeerFromNonSubscriber_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
-        String garbageText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
-                FIELD_SEPARATOR + "+393338512123";
+        String garbageText =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" + FIELD_SEPARATOR
+                        + "+393338512123";
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
 
@@ -340,15 +465,16 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#AddPeer} containing an invalid phone
-     * number is ignored.
+     * Tests whether a message with {@link RequestType#AddPeer} containing an invalid phone number
+     * is ignored.
      */
     @Test
     public void onMessageReceived_addPeerWithWrongNumber_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
-        String garbageText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
-                FIELD_SEPARATOR + "+0000333812123";
+        String garbageText =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" + FIELD_SEPARATOR
+                        + "+0000333812123";
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
@@ -366,15 +492,42 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#AddPeer} and proper formatting is
-     * correctly processed.
+     * Tests whether a message with {@link RequestType#AddPeer} containing no peers to be added is
+     * ignored.
+     */
+    @Test
+    public void onMessageReceived_addPeerWithNoPeers_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + "" + FIELD_SEPARATOR;
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(new SMSNetDictionary());
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockSubscribers, never()).addSubscriber(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#AddPeer} and proper formatting is correctly
+     * processed.
      */
     @Test
     public void onMessageReceived_correctAddPeer() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
-        String correctText = RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" +
-                FIELD_SEPARATOR + "+39333812123";
+        String correctText =
+                RequestType.AddPeer.asString() + FIELD_SEPARATOR + "+393478512584" + FIELD_SEPARATOR
+                        + "+39333812123";
         SMSMessage correctMessage = new SMSMessage(sender, correctText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
@@ -393,14 +546,99 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#AddResource} and containing no
-     * key-resource pairs is ignored.
+     * Tests whether a message with {@link RequestType#AddResource} and containing no key-resource
+     * pairs is ignored.
      */
     @Test
     public void onMessageReceived_addResourceWithNoResources_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
         String garbageText = RequestType.AddResource.asString();
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#AddResource} coming from somebody who's not a
+     * subscriber is ignored.
+     */
+    @Test
+    public void onMessageReceived_addResourceFromNonSubscriber_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText =
+                RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is" +
+                        FIELD_SEPARATOR + "under the table";
+        SMSMessage garbageMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#AddResource} and containing a key with no
+     * associated resource is ignored.
+     */
+    @Test
+    public void onMessageReceived_addResourceWithKeyButNoAssociatedResource_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText =
+                RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is";
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).addResourceFromSMS(any(), any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#AddResource} and containing an invalid
+     * resource is ignored.
+     */
+    @Test
+    public void onMessageReceived_addResourceWithInvalidResource_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText =
+                RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is" +
+                        FIELD_SEPARATOR + "under the table\\";
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
@@ -426,9 +664,10 @@ public class BroadcastReceiverTest {
     public void onMessageReceived_correctAddResource() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
-        String correctText = RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is " +
-                "on" + FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is" +
-                FIELD_SEPARATOR + "under the table";
+        String correctText =
+                RequestType.AddResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table" + FIELD_SEPARATOR + "the book is" +
+                        FIELD_SEPARATOR + "under the table";
         SMSMessage correctMessage = new SMSMessage(sender, correctText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
@@ -448,14 +687,69 @@ public class BroadcastReceiverTest {
     }
 
     /**
-     * Tests whether a message with {@link RequestType#RemoveResource} and no keys of the
-     * resources to remove is ignored.
+     * Tests whether a message with {@link RequestType#RemoveResource} and no keys of the resources
+     * to remove is ignored.
      */
     @Test
     public void onMessageReceived_removeResourceWithNoResources_isIgnored() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
         String garbageText = RequestType.RemoveResource.asString();
+        SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+        subscribersSet.add(sender);
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).removeResourceFromSMS(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#RemoveResource} from somebody who's not a
+     * subscriber is ignored.
+     */
+    @Test
+    public void onMessageReceived_removeResourceFromNonSubscriber_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String correctText =
+                RequestType.RemoveResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table";
+        SMSMessage garbageMessage = new SMSMessage(sender, correctText);
+        Set<SMSPeer> subscribersSet = new HashSet<>();
+
+        SMSNetSubscriberList mockSubscribers = mock(SMSNetSubscriberList.class);
+        when(mockSubscribers.getSubscribers()).thenReturn(subscribersSet);
+        SMSNetDictionary mockDictionary = mock(SMSNetDictionary.class);
+        SMSJoinableNetManager mockManager = mock(SMSJoinableNetManager.class);
+        when(mockManager.getNetSubscriberList()).thenReturn(mockSubscribers);
+        when(mockManager.getNetDictionary()).thenReturn(mockDictionary);
+        PowerMockito.mockStatic(SMSJoinableNetManager.class);
+        when(SMSJoinableNetManager.getInstance()).thenReturn(mockManager);
+
+        instance.onMessageReceived(garbageMessage);
+        verify(mockDictionary, never()).removeResourceFromSMS(any());
+    }
+
+    /**
+     * Tests whether a message with {@link RequestType#RemoveResource} containing an invalid key is
+     * ignored.
+     */
+    @Test
+    public void onMessageReceived_removeResourceWithInvalidKey_isIgnored() {
+        BroadcastReceiver instance = new BroadcastReceiver();
+        SMSPeer sender = new SMSPeer("+393492794133");
+        String garbageText =
+                RequestType.RemoveResource.asString() + FIELD_SEPARATOR + "the cat is on" +
+                        FIELD_SEPARATOR + "the table\\";
         SMSMessage garbageMessage = new SMSMessage(sender, garbageText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);
@@ -481,8 +775,9 @@ public class BroadcastReceiverTest {
     public void onMessageReceived_correctRemoveResource() {
         BroadcastReceiver instance = new BroadcastReceiver();
         SMSPeer sender = new SMSPeer("+393492794133");
-        String correctText = RequestType.RemoveResource.asString() + FIELD_SEPARATOR + "the cat " +
-                "is on" + FIELD_SEPARATOR + "the table";
+        String correctText =
+                RequestType.RemoveResource.asString() + FIELD_SEPARATOR + "the cat " + "is on" +
+                        FIELD_SEPARATOR + "the table";
         SMSMessage correctMessage = new SMSMessage(sender, correctText);
         Set<SMSPeer> subscribersSet = new HashSet<>();
         subscribersSet.add(sender);


### PR DESCRIPTION
Class `BroadcastReceiver` is part of the replicated dictionary made for the first version of geocalendar, it interprets every received SMS and acts according to its content.

If you have any trouble understanding how backslashes are added and removed you can take a look at https://github.com/EIS0/network-dictionary/blob/code-review/giovannivelludo-readded-files/networklibrary/src/main/java/com/eis/smsnetwork/SMSNetDictionary.java. I didn't include that class in this review because there would have been too many lines of code.

Calls to `Log` were left because they can be removed automatically by ProGuard when building a release of the application using this library.